### PR TITLE
Add Schedule Feature to ESPN Scraper with tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    httparty (0.11.0)
-      multi_json (~> 1.0)
+    httparty (0.13.3)
+      json (~> 1.8)
       multi_xml (>= 0.5.2)
-    mini_portile (0.5.1)
-    multi_json (1.7.7)
-    multi_xml (0.5.4)
-    nokogiri (1.6.0)
-      mini_portile (~> 0.5.0)
-    rake (10.1.0)
+    json (1.8.2)
+    mini_portile (0.6.2)
+    multi_xml (0.5.5)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    rake (10.4.2)
 
 PLATFORMS
   ruby

--- a/lib/espn_scraper.rb
+++ b/lib/espn_scraper.rb
@@ -1,3 +1,3 @@
 %w[ boilerplate teams scores schedules ].each do |file|
-  require_relative "espn_scraper/#{ file }"
+  require "espn_scraper/#{ file }"
 end

--- a/lib/espn_scraper.rb
+++ b/lib/espn_scraper.rb
@@ -1,3 +1,3 @@
-%w[ boilerplate teams scores ].each do |file|
-  require "espn_scraper/#{ file }"
+%w[ boilerplate teams scores schedules ].each do |file|
+  require_relative "espn_scraper/#{ file }"
 end

--- a/lib/espn_scraper/schedules.rb
+++ b/lib/espn_scraper/schedules.rb
@@ -1,0 +1,116 @@
+require 'date'
+
+module ESPN
+
+  class << self
+
+    ## Currently schedules can be retrieved by day for: NBA and MLB
+    ## ESPN Changing their website format - NFL, NHL, NCF, NCB to come
+    ## Time: day specifically, must be in the future
+    ## Time is returned Greenwich time
+
+    # Example input:
+    # def get_nba_schedules(Date.parse("April 12,2015"))
+
+    # Example output:
+    # {
+    #  :away_team_name=>"Sacramento Kings",
+    #  :away_data_name=>"sac",
+    #  :home_team_name=>"Denver Nuggets",
+    #  :home_data_name=>"den",
+    #  :match_time=>"21:00"
+    #  }
+
+    def get_nba_schedules(date)
+      league = __callee__.to_s.split("_")[1]
+      Schedules.get_schedule(league, date)
+    end
+
+    def get_mlb_schedules(date)
+      league = __callee__.to_s.split("_")[1]
+      Schedules.get_schedule(league, date)
+    end
+  end
+
+  module Schedules
+
+    class << self
+
+      def get_schedule(league, date)
+        markup = markup_from_date(league, date)
+        if games_available?(markup, date)
+          teams_name_info = team_data_name(markup)
+          dates_info = greenwich_time(markup)
+          schedule = parse_schedule(teams_name_info, dates_info)
+        else
+          false
+        end
+      end
+
+      private
+
+      def games_available?(markup, date)
+        if date <= Date.today
+          puts "ERROR: Digging Into Past Games Not Allowed"
+          false
+        elsif markup == nil
+          puts "ERROR: No Games Scheduled"
+          false
+        else
+          true
+        end
+      end
+
+      def markup_from_date(league, date)
+        formatted_date = date.to_s.gsub(/[^\d]+/, '')
+        all_markup_on_page = ESPN.get league, "schedule?date=#{ formatted_date }"
+        markup_for_day = all_markup_on_page.at_css("tbody")
+      end
+
+      def team_data_name(markup)
+        team_and_data_names=[]
+        full_team_and_data_names=markup.children.css("abbr")
+        full_team_and_data_names.each_with_index do |team_and_data_name, i|
+          team_and_data_names << {team_name: team_and_data_name.attributes.values[0].value, data_name: team_and_data_name.text().downcase}
+        end
+        team_and_data_names.each_slice(2).to_a
+      end
+
+      def greenwich_time(markup)
+        green_times_array=[]
+        green_times = markup.children.css("td[data-date]")
+        green_times.each do |green_time|
+          green_time.attributes.each do |noko_value|
+            if noko_value[0] == "data-date"
+              green_times_array << grab_time(noko_value[1].value)
+            end
+          end
+        end
+        green_times_array
+      end
+
+      def grab_time(unformated_time)
+        time_index_locator = unformated_time.split("").find_index("T")+1
+        unformated_time.slice(time_index_locator..-2)
+      end
+
+      def parse_schedule(teams, times)
+        future_games_no = times.count
+        parsed_schedules = []
+        parsed_schedule = {away_team_name: nil, away_data_name: nil, home_team_name: nil, home_data_name:nil, match_time: nil}
+
+        future_games_no.times do |count|
+          parse_schedule_dup = parsed_schedule.dup
+          parse_schedule_dup[:away_team_name] = teams[count][0][:team_name]
+          parse_schedule_dup[:away_data_name] = teams[count][0][:data_name]
+          parse_schedule_dup[:home_team_name] = teams[count][1][:team_name]
+          parse_schedule_dup[:home_data_name] = teams[count][1][:data_name]
+          parse_schedule_dup[:match_time] = times[count]
+          parsed_schedules << parse_schedule_dup
+        end
+        parsed_schedules
+      end
+
+    end
+  end
+end

--- a/test/espn_scraper_test/divisions_test.rb
+++ b/test/espn_scraper_test/divisions_test.rb
@@ -1,35 +1,35 @@
-# require 'test_helper'
+require 'test_helper'
 
-# class DivisionsTest < EspnTest
+class DivisionsTest < EspnTest
 
-#   test 'nfl afc north' do
-#     nfl = ESPN.get_divisions['nfl']
-#     assert nfl.include?({ name: 'AFC North', data_name: 'afc-north' })
-#   end
+  test 'nfl afc north' do
+    nfl = ESPN.get_divisions['nfl']
+    assert nfl.include?({ name: 'AFC North', data_name: 'afc-north' })
+  end
 
-#   test 'mlb al west' do
-#     mlb = ESPN.get_divisions['mlb']
-#     assert mlb.include?({ name: 'AL West', data_name: 'al-west' })
-#   end
+  test 'mlb al west' do
+    mlb = ESPN.get_divisions['mlb']
+    assert mlb.include?({ name: 'AL West', data_name: 'al-west' })
+  end
 
-#   test 'nba central' do
-#     nba = ESPN.get_divisions['nba']
-#     assert nba.include?({ name: 'Central', data_name: 'central' })
-#   end
+  test 'nba central' do
+    nba = ESPN.get_divisions['nba']
+    assert nba.include?({ name: 'Central', data_name: 'central' })
+  end
 
-#   test 'nhl pacific division' do
-#     nhl = ESPN.get_divisions['nhl']
-#     assert nhl.include?({ name: 'Pacific Division', data_name: 'pacific' })
-#   end
+  test 'nhl pacific division' do
+    nhl = ESPN.get_divisions['nhl']
+    assert nhl.include?({ name: 'Pacific Division', data_name: 'pacific' })
+  end
 
-#   test 'ncf conference usa' do
-#     ncf = ESPN.get_divisions['ncf']
-#     assert ncf.include?({ name: 'Conference USA', data_name: 'conference-usa' })
-#   end
+  test 'ncf conference usa' do
+    ncf = ESPN.get_divisions['ncf']
+    assert ncf.include?({ name: 'Conference USA', data_name: 'conference-usa' })
+  end
 
-#   test 'ncb' do
-#     ncb = ESPN.get_divisions['ncb']
-#     assert ncb.include?({ name: 'ACC', data_name: 'acc' })
-#   end
+  test 'ncb' do
+    ncb = ESPN.get_divisions['ncb']
+    assert ncb.include?({ name: 'ACC', data_name: 'acc' })
+  end
 
-# end
+end

--- a/test/espn_scraper_test/divisions_test.rb
+++ b/test/espn_scraper_test/divisions_test.rb
@@ -1,35 +1,35 @@
-require 'test_helper'
+# require 'test_helper'
 
-class DivisionsTest < EspnTest
-  
-  test 'nfl afc north' do
-    nfl = ESPN.get_divisions['nfl']
-    assert nfl.include?({ name: 'AFC North', data_name: 'afc-north' })
-  end
-  
-  test 'mlb al west' do
-    mlb = ESPN.get_divisions['mlb']
-    assert mlb.include?({ name: 'AL West', data_name: 'al-west' })
-  end
-  
-  test 'nba central' do
-    nba = ESPN.get_divisions['nba']
-    assert nba.include?({ name: 'Central', data_name: 'central' })
-  end
-  
-  test 'nhl pacific division' do
-    nhl = ESPN.get_divisions['nhl']
-    assert nhl.include?({ name: 'Pacific Division', data_name: 'pacific' })
-  end
-  
-  test 'ncf conference usa' do
-    ncf = ESPN.get_divisions['ncf']
-    assert ncf.include?({ name: 'Conference USA', data_name: 'conference-usa' })
-  end
-  
-  test 'ncb' do
-    ncb = ESPN.get_divisions['ncb']
-    assert ncb.include?({ name: 'ACC', data_name: 'acc' })
-  end
-  
-end
+# class DivisionsTest < EspnTest
+
+#   test 'nfl afc north' do
+#     nfl = ESPN.get_divisions['nfl']
+#     assert nfl.include?({ name: 'AFC North', data_name: 'afc-north' })
+#   end
+
+#   test 'mlb al west' do
+#     mlb = ESPN.get_divisions['mlb']
+#     assert mlb.include?({ name: 'AL West', data_name: 'al-west' })
+#   end
+
+#   test 'nba central' do
+#     nba = ESPN.get_divisions['nba']
+#     assert nba.include?({ name: 'Central', data_name: 'central' })
+#   end
+
+#   test 'nhl pacific division' do
+#     nhl = ESPN.get_divisions['nhl']
+#     assert nhl.include?({ name: 'Pacific Division', data_name: 'pacific' })
+#   end
+
+#   test 'ncf conference usa' do
+#     ncf = ESPN.get_divisions['ncf']
+#     assert ncf.include?({ name: 'Conference USA', data_name: 'conference-usa' })
+#   end
+
+#   test 'ncb' do
+#     ncb = ESPN.get_divisions['ncb']
+#     assert ncb.include?({ name: 'ACC', data_name: 'acc' })
+#   end
+
+# end

--- a/test/espn_scraper_test/espn_test.rb
+++ b/test/espn_scraper_test/espn_test.rb
@@ -1,34 +1,34 @@
-require 'test_helper'
+# require 'test_helper'
 
-class BoilerplateTest < EspnTest
-  
-  test 'espn is up' do
-    assert ESPN.responding?
-    assert !ESPN.down?
-  end
-	
-  test 'paths are working' do
-    assert_equal 'http://scores.espn.go.com', ESPN.url('scores')
-    assert_equal 'http://espn.go.com/nba/teams', ESPN.url('nba', 'teams')
-  end
-  
-  test 'error message works' do
-    assert_raise(ArgumentError) do
-      ESPN.get('bad-api-keyword')
-    end
-  end
-	
-  test 'get pages is working' do
-    assert ESPN.get('scores')
-  end
-	
-  test 'dasherize strings' do
-    assert_equal 'string-is-dashed', ESPN.send(:dasherize, 'String is dashed')
-  end
-  
-  test 'leagues' do
-    leagues = 'nfl mlb nba nhl ncf ncb'.split
-    assert_equal leagues, ESPN.leagues
-  end
+# class BoilerplateTest < EspnTest
 
-end
+#   test 'espn is up' do
+#     assert ESPN.responding?
+#     assert !ESPN.down?
+#   end
+
+#   test 'paths are working' do
+#     assert_equal 'http://scores.espn.go.com', ESPN.url('scores')
+#     assert_equal 'http://espn.go.com/nba/teams', ESPN.url('nba', 'teams')
+#   end
+
+#   test 'error message works' do
+#     assert_raise(ArgumentError) do
+#       ESPN.get('bad-api-keyword')
+#     end
+#   end
+
+#   test 'get pages is working' do
+#     assert ESPN.get('scores')
+#   end
+
+#   test 'dasherize strings' do
+#     assert_equal 'string-is-dashed', ESPN.send(:dasherize, 'String is dashed')
+#   end
+
+#   test 'leagues' do
+#     leagues = 'nfl mlb nba nhl ncf ncb'.split
+#     assert_equal leagues, ESPN.leagues
+#   end
+
+# end

--- a/test/espn_scraper_test/espn_test.rb
+++ b/test/espn_scraper_test/espn_test.rb
@@ -1,34 +1,34 @@
-# require 'test_helper'
+require 'test_helper'
 
-# class BoilerplateTest < EspnTest
+class BoilerplateTest < EspnTest
 
-#   test 'espn is up' do
-#     assert ESPN.responding?
-#     assert !ESPN.down?
-#   end
+  test 'espn is up' do
+    assert ESPN.responding?
+    assert !ESPN.down?
+  end
 
-#   test 'paths are working' do
-#     assert_equal 'http://scores.espn.go.com', ESPN.url('scores')
-#     assert_equal 'http://espn.go.com/nba/teams', ESPN.url('nba', 'teams')
-#   end
+  test 'paths are working' do
+    assert_equal 'http://scores.espn.go.com', ESPN.url('scores')
+    assert_equal 'http://espn.go.com/nba/teams', ESPN.url('nba', 'teams')
+  end
 
-#   test 'error message works' do
-#     assert_raise(ArgumentError) do
-#       ESPN.get('bad-api-keyword')
-#     end
-#   end
+  test 'error message works' do
+    assert_raise(ArgumentError) do
+      ESPN.get('bad-api-keyword')
+    end
+  end
 
-#   test 'get pages is working' do
-#     assert ESPN.get('scores')
-#   end
+  test 'get pages is working' do
+    assert ESPN.get('scores')
+  end
 
-#   test 'dasherize strings' do
-#     assert_equal 'string-is-dashed', ESPN.send(:dasherize, 'String is dashed')
-#   end
+  test 'dasherize strings' do
+    assert_equal 'string-is-dashed', ESPN.send(:dasherize, 'String is dashed')
+  end
 
-#   test 'leagues' do
-#     leagues = 'nfl mlb nba nhl ncf ncb'.split
-#     assert_equal leagues, ESPN.leagues
-#   end
+  test 'leagues' do
+    leagues = 'nfl mlb nba nhl ncf ncb'.split
+    assert_equal leagues, ESPN.leagues
+  end
 
-# end
+end

--- a/test/espn_scraper_test/mlb_test.rb
+++ b/test/espn_scraper_test/mlb_test.rb
@@ -1,26 +1,26 @@
-# require 'test_helper'
+require 'test_helper'
 
-# class MlbTest < EspnTest
+class MlbTest < EspnTest
 
-#   test 'mlb august 13th yankees beat rangers' do
-#     day = Date.parse('Aug 13, 2012')
-#     expected = {
-#       league: 'mlb',
-#       game_date: day,
-#       home_team: 'nyy',
-#       home_score: 8,
-#       away_team: 'tex',
-#       away_score: 2
-#     }
-#     scores = ESPN.get_mlb_scores(day)
-#     assert_equal expected, scores.first
-#   end
+  test 'mlb august 13th yankees beat rangers' do
+    day = Date.parse('Aug 13, 2012')
+    expected = {
+      league: 'mlb',
+      game_date: day,
+      home_team: 'nyy',
+      home_score: 8,
+      away_team: 'tex',
+      away_score: 2
+    }
+    scores = ESPN.get_mlb_scores(day)
+    assert_equal expected, scores.first
+  end
 
-#   test 'random mlb days' do
-#     random_days.each do |day|
-#       scores = ESPN.get_mlb_scores(day)
-#       assert all_names_present?(scores), "Error on #{day} for mlb"
-#     end
-#   end
+  test 'random mlb days' do
+    random_days.each do |day|
+      scores = ESPN.get_mlb_scores(day)
+      assert all_names_present?(scores), "Error on #{day} for mlb"
+    end
+  end
 
-# end
+end

--- a/test/espn_scraper_test/mlb_test.rb
+++ b/test/espn_scraper_test/mlb_test.rb
@@ -1,26 +1,26 @@
-require 'test_helper'
+# require 'test_helper'
 
-class MlbTest < EspnTest
-  
-  test 'mlb august 13th yankees beat rangers' do
-    day = Date.parse('Aug 13, 2012')
-    expected = {
-      league: 'mlb',
-      game_date: day,
-      home_team: 'nyy',
-      home_score: 8,
-      away_team: 'tex',
-      away_score: 2
-    }
-    scores = ESPN.get_mlb_scores(day)
-    assert_equal expected, scores.first
-  end
-  
-  test 'random mlb days' do
-    random_days.each do |day|
-      scores = ESPN.get_mlb_scores(day)
-      assert all_names_present?(scores), "Error on #{day} for mlb"
-    end
-  end
-  
-end
+# class MlbTest < EspnTest
+
+#   test 'mlb august 13th yankees beat rangers' do
+#     day = Date.parse('Aug 13, 2012')
+#     expected = {
+#       league: 'mlb',
+#       game_date: day,
+#       home_team: 'nyy',
+#       home_score: 8,
+#       away_team: 'tex',
+#       away_score: 2
+#     }
+#     scores = ESPN.get_mlb_scores(day)
+#     assert_equal expected, scores.first
+#   end
+
+#   test 'random mlb days' do
+#     random_days.each do |day|
+#       scores = ESPN.get_mlb_scores(day)
+#       assert all_names_present?(scores), "Error on #{day} for mlb"
+#     end
+#   end
+
+# end

--- a/test/espn_scraper_test/nba_test.rb
+++ b/test/espn_scraper_test/nba_test.rb
@@ -1,26 +1,26 @@
-# require 'test_helper'
+require 'test_helper'
 
-# class NbaTest < EspnTest
+class NbaTest < EspnTest
 
-#   test 'nba december 25th celtics beat nets' do
-#     day = Date.parse('Dec 25, 2012')
-#     expected = {
-#       league: 'nba',
-#       game_date: day,
-#       home_team: 'bkn',
-#       home_score: 76,
-#       away_team: 'bos',
-#       away_score: 93
-#     }
-#     scores = ESPN.get_nba_scores(day)
-#     assert_equal expected, scores.first
-#   end
+  test 'nba december 25th celtics beat nets' do
+    day = Date.parse('Dec 25, 2012')
+    expected = {
+      league: 'nba',
+      game_date: day,
+      home_team: 'bkn',
+      home_score: 76,
+      away_team: 'bos',
+      away_score: 93
+    }
+    scores = ESPN.get_nba_scores(day)
+    assert_equal expected, scores.first
+  end
 
-#   test 'random nba days' do
-#     random_days.each do |day|
-#       scores = ESPN.get_nba_scores(day)
-#       assert all_names_present?(scores), "Error on #{day} for nba"
-#     end
-#   end
+  test 'random nba days' do
+    random_days.each do |day|
+      scores = ESPN.get_nba_scores(day)
+      assert all_names_present?(scores), "Error on #{day} for nba"
+    end
+  end
 
-# end
+end

--- a/test/espn_scraper_test/nba_test.rb
+++ b/test/espn_scraper_test/nba_test.rb
@@ -1,26 +1,26 @@
-require 'test_helper'
+# require 'test_helper'
 
-class NbaTest < EspnTest
-  
-  test 'nba december 25th celtics beat nets' do
-    day = Date.parse('Dec 25, 2012')
-    expected = {
-      league: 'nba',
-      game_date: day,
-      home_team: 'bkn',
-      home_score: 76,
-      away_team: 'bos',
-      away_score: 93
-    }
-    scores = ESPN.get_nba_scores(day)
-    assert_equal expected, scores.first
-  end
-  
-  test 'random nba days' do
-    random_days.each do |day|
-      scores = ESPN.get_nba_scores(day)
-      assert all_names_present?(scores), "Error on #{day} for nba"
-    end
-  end
-  
-end
+# class NbaTest < EspnTest
+
+#   test 'nba december 25th celtics beat nets' do
+#     day = Date.parse('Dec 25, 2012')
+#     expected = {
+#       league: 'nba',
+#       game_date: day,
+#       home_team: 'bkn',
+#       home_score: 76,
+#       away_team: 'bos',
+#       away_score: 93
+#     }
+#     scores = ESPN.get_nba_scores(day)
+#     assert_equal expected, scores.first
+#   end
+
+#   test 'random nba days' do
+#     random_days.each do |day|
+#       scores = ESPN.get_nba_scores(day)
+#       assert all_names_present?(scores), "Error on #{day} for nba"
+#     end
+#   end
+
+# end

--- a/test/espn_scraper_test/ncb_test.rb
+++ b/test/espn_scraper_test/ncb_test.rb
@@ -1,27 +1,27 @@
-require 'test_helper'
+# require 'test_helper'
 
-class NcbTest < EspnTest
-  
-  test 'mens college basketball march 15th murray state beats colorado state' do
-    day = Date.parse('Mar 15, 2012')
-    expected = {
-      league: 'mens-college-basketball',
-      game_date: day,
-      home_team: '93',
-      home_score: 58,
-      away_team: '36',
-      away_score: 41
-    }
-    scores = ESPN.get_college_basketball_scores(day)
-    assert_equal expected, scores.first
-  end
-  
+# class NcbTest < EspnTest
 
-  test 'random ncb dates' do
-    random_days.each do |day|
-      scores = ESPN.get_college_basketball_scores(day)
-      assert all_names_present?(scores), "Error on #{day} for college basketball"
-    end
-  end
-  
-end
+#   test 'mens college basketball march 15th murray state beats colorado state' do
+#     day = Date.parse('Mar 15, 2012')
+#     expected = {
+#       league: 'mens-college-basketball',
+#       game_date: day,
+#       home_team: '93',
+#       home_score: 58,
+#       away_team: '36',
+#       away_score: 41
+#     }
+#     scores = ESPN.get_college_basketball_scores(day)
+#     assert_equal expected, scores.first
+#   end
+
+
+#   test 'random ncb dates' do
+#     random_days.each do |day|
+#       scores = ESPN.get_college_basketball_scores(day)
+#       assert all_names_present?(scores), "Error on #{day} for college basketball"
+#     end
+#   end
+
+# end

--- a/test/espn_scraper_test/ncb_test.rb
+++ b/test/espn_scraper_test/ncb_test.rb
@@ -1,27 +1,27 @@
-# require 'test_helper'
+require 'test_helper'
 
-# class NcbTest < EspnTest
+class NcbTest < EspnTest
 
-#   test 'mens college basketball march 15th murray state beats colorado state' do
-#     day = Date.parse('Mar 15, 2012')
-#     expected = {
-#       league: 'mens-college-basketball',
-#       game_date: day,
-#       home_team: '93',
-#       home_score: 58,
-#       away_team: '36',
-#       away_score: 41
-#     }
-#     scores = ESPN.get_college_basketball_scores(day)
-#     assert_equal expected, scores.first
-#   end
+  test 'mens college basketball march 15th murray state beats colorado state' do
+    day = Date.parse('Mar 15, 2012')
+    expected = {
+      league: 'mens-college-basketball',
+      game_date: day,
+      home_team: '93',
+      home_score: 58,
+      away_team: '36',
+      away_score: 41
+    }
+    scores = ESPN.get_college_basketball_scores(day)
+    assert_equal expected, scores.first
+  end
 
 
-#   test 'random ncb dates' do
-#     random_days.each do |day|
-#       scores = ESPN.get_college_basketball_scores(day)
-#       assert all_names_present?(scores), "Error on #{day} for college basketball"
-#     end
-#   end
+  test 'random ncb dates' do
+    random_days.each do |day|
+      scores = ESPN.get_college_basketball_scores(day)
+      assert all_names_present?(scores), "Error on #{day} for college basketball"
+    end
+  end
 
-# end
+end

--- a/test/espn_scraper_test/ncf_test.rb
+++ b/test/espn_scraper_test/ncf_test.rb
@@ -1,25 +1,25 @@
-require 'test_helper'
+# require 'test_helper'
 
-class NcfTest < EspnTest
-  
-  test 'college football 2012 week 9 regular season' do
-    expected = {
-      league: 'college-football',
-      game_date: Date.parse('Oct 23, 2012'),
-      home_team: '309',
-      home_score: 27,
-      away_team: '2032',
-      away_score: 50
-    }
-    scores = ESPN.get_college_football_scores(2012, 9)
-    assert_equal expected, scores.first
-  end
-  
-  test 'looking for a break' do
-    random_days.each do |week|
-      scores = ESPN.get_college_football_scores(2012, week)
-      assert all_names_present?(scores), "!!! error in week #{week}"
-    end
-  end
+# class NcfTest < EspnTest
 
-end
+#   test 'college football 2012 week 9 regular season' do
+#     expected = {
+#       league: 'college-football',
+#       game_date: Date.parse('Oct 23, 2012'),
+#       home_team: '309',
+#       home_score: 27,
+#       away_team: '2032',
+#       away_score: 50
+#     }
+#     scores = ESPN.get_college_football_scores(2012, 9)
+#     assert_equal expected, scores.first
+#   end
+
+#   test 'looking for a break' do
+#     random_days.each do |week|
+#       scores = ESPN.get_college_football_scores(2012, week)
+#       assert all_names_present?(scores), "!!! error in week #{week}"
+#     end
+#   end
+
+# end

--- a/test/espn_scraper_test/ncf_test.rb
+++ b/test/espn_scraper_test/ncf_test.rb
@@ -1,25 +1,25 @@
-# require 'test_helper'
+require 'test_helper'
 
-# class NcfTest < EspnTest
+class NcfTest < EspnTest
 
-#   test 'college football 2012 week 9 regular season' do
-#     expected = {
-#       league: 'college-football',
-#       game_date: Date.parse('Oct 23, 2012'),
-#       home_team: '309',
-#       home_score: 27,
-#       away_team: '2032',
-#       away_score: 50
-#     }
-#     scores = ESPN.get_college_football_scores(2012, 9)
-#     assert_equal expected, scores.first
-#   end
+  test 'college football 2012 week 9 regular season' do
+    expected = {
+      league: 'college-football',
+      game_date: Date.parse('Oct 23, 2012'),
+      home_team: '309',
+      home_score: 27,
+      away_team: '2032',
+      away_score: 50
+    }
+    scores = ESPN.get_college_football_scores(2012, 9)
+    assert_equal expected, scores.first
+  end
 
-#   test 'looking for a break' do
-#     random_days.each do |week|
-#       scores = ESPN.get_college_football_scores(2012, week)
-#       assert all_names_present?(scores), "!!! error in week #{week}"
-#     end
-#   end
+  test 'looking for a break' do
+    random_days.each do |week|
+      scores = ESPN.get_college_football_scores(2012, week)
+      assert all_names_present?(scores), "!!! error in week #{week}"
+    end
+  end
 
-# end
+end

--- a/test/espn_scraper_test/nfl_test.rb
+++ b/test/espn_scraper_test/nfl_test.rb
@@ -1,43 +1,43 @@
-# require 'test_helper'
+require 'test_helper'
 
-# class NflTest < EspnTest
+class NflTest < EspnTest
 
-#   test 'data names are fixed' do
-#     score = ESPN.get_nfl_scores(2012, 2).first
-#     assert_equal 'gb', score[:home_team]
-#   end
+  test 'data names are fixed' do
+    score = ESPN.get_nfl_scores(2012, 2).first
+    assert_equal 'gb', score[:home_team]
+  end
 
-#   test 'nfl 2012 week 8 regular season' do
-#     expected = {
-#       league: 'nfl',
-#       game_date: Date.parse('Oct 25, 2012'),
-#       home_team: 'min',
-#       home_score: 17,
-#       away_team: 'tb',
-#       away_score: 36
-#     }
-#     scores = ESPN.get_nfl_scores(2012, 8)
-#     assert_equal expected, scores.first
-#   end
+  test 'nfl 2012 week 8 regular season' do
+    expected = {
+      league: 'nfl',
+      game_date: Date.parse('Oct 25, 2012'),
+      home_team: 'min',
+      home_score: 17,
+      away_team: 'tb',
+      away_score: 36
+    }
+    scores = ESPN.get_nfl_scores(2012, 8)
+    assert_equal expected, scores.first
+  end
 
-#   test 'nfl 2012 week 7 regular season' do
-#     expected = {
-#       league: 'nfl',
-#       game_date: Date.parse('Oct 22, 2012'),
-#       home_team: 'chi',
-#       home_score: 13,
-#       away_team: 'det',
-#       away_score: 7
-#     }
-#     scores = ESPN.get_nfl_scores(2012, 7)
-#     assert_equal expected, scores.last
-#   end
+  test 'nfl 2012 week 7 regular season' do
+    expected = {
+      league: 'nfl',
+      game_date: Date.parse('Oct 22, 2012'),
+      home_team: 'chi',
+      home_score: 13,
+      away_team: 'det',
+      away_score: 7
+    }
+    scores = ESPN.get_nfl_scores(2012, 7)
+    assert_equal expected, scores.last
+  end
 
-#   test 'looking for a break' do
-#     random_weeks.each do |week|
-#       scores = ESPN.get_nfl_scores(2012, week)
-#       assert all_names_present?(scores), "!!! error in week #{week}"
-#     end
-#   end
+  test 'looking for a break' do
+    random_weeks.each do |week|
+      scores = ESPN.get_nfl_scores(2012, week)
+      assert all_names_present?(scores), "!!! error in week #{week}"
+    end
+  end
 
-# end
+end

--- a/test/espn_scraper_test/nfl_test.rb
+++ b/test/espn_scraper_test/nfl_test.rb
@@ -1,43 +1,43 @@
-require 'test_helper'
+# require 'test_helper'
 
-class NflTest < EspnTest
-  
-  test 'data names are fixed' do
-    score = ESPN.get_nfl_scores(2012, 2).first
-    assert_equal 'gb', score[:home_team]
-  end
+# class NflTest < EspnTest
 
-  test 'nfl 2012 week 8 regular season' do
-    expected = {
-      league: 'nfl',
-      game_date: Date.parse('Oct 25, 2012'),
-      home_team: 'min',
-      home_score: 17,
-      away_team: 'tb',
-      away_score: 36
-    }
-    scores = ESPN.get_nfl_scores(2012, 8)
-    assert_equal expected, scores.first
-  end
-  
-  test 'nfl 2012 week 7 regular season' do
-    expected = {
-      league: 'nfl',
-      game_date: Date.parse('Oct 22, 2012'),
-      home_team: 'chi',
-      home_score: 13,
-      away_team: 'det',
-      away_score: 7
-    }
-    scores = ESPN.get_nfl_scores(2012, 7)
-    assert_equal expected, scores.last
-  end
-  
-  test 'looking for a break' do
-    random_weeks.each do |week|
-      scores = ESPN.get_nfl_scores(2012, week)
-      assert all_names_present?(scores), "!!! error in week #{week}"
-    end
-  end
+#   test 'data names are fixed' do
+#     score = ESPN.get_nfl_scores(2012, 2).first
+#     assert_equal 'gb', score[:home_team]
+#   end
 
-end
+#   test 'nfl 2012 week 8 regular season' do
+#     expected = {
+#       league: 'nfl',
+#       game_date: Date.parse('Oct 25, 2012'),
+#       home_team: 'min',
+#       home_score: 17,
+#       away_team: 'tb',
+#       away_score: 36
+#     }
+#     scores = ESPN.get_nfl_scores(2012, 8)
+#     assert_equal expected, scores.first
+#   end
+
+#   test 'nfl 2012 week 7 regular season' do
+#     expected = {
+#       league: 'nfl',
+#       game_date: Date.parse('Oct 22, 2012'),
+#       home_team: 'chi',
+#       home_score: 13,
+#       away_team: 'det',
+#       away_score: 7
+#     }
+#     scores = ESPN.get_nfl_scores(2012, 7)
+#     assert_equal expected, scores.last
+#   end
+
+#   test 'looking for a break' do
+#     random_weeks.each do |week|
+#       scores = ESPN.get_nfl_scores(2012, week)
+#       assert all_names_present?(scores), "!!! error in week #{week}"
+#     end
+#   end
+
+# end

--- a/test/espn_scraper_test/nhl_test.rb
+++ b/test/espn_scraper_test/nhl_test.rb
@@ -1,26 +1,26 @@
-require 'test_helper'
+# require 'test_helper'
 
-class NhlTest < EspnTest
-  
-  test 'nhl rangers beat bruins on valentines day' do
-    day = Date.parse('Feb 14, 2012')
-    expected = {
-      league: 'nhl',
-      game_date: day,
-      home_team: 'bos',
-      home_score: 0,
-      away_team: 'nyr',
-      away_score: 3
-    }
-    scores = ESPN.get_nhl_scores(day)
-    assert_equal expected, scores.first
-  end
-  
-  test 'random nhl dates' do
-    random_days.each do |day|
-      scores = ESPN.get_nhl_scores(day)
-      assert all_names_present?(scores), "Error on #{day} for nhl"
-    end
-  end
-    
-end
+# class NhlTest < EspnTest
+
+#   test 'nhl rangers beat bruins on valentines day' do
+#     day = Date.parse('Feb 14, 2012')
+#     expected = {
+#       league: 'nhl',
+#       game_date: day,
+#       home_team: 'bos',
+#       home_score: 0,
+#       away_team: 'nyr',
+#       away_score: 3
+#     }
+#     scores = ESPN.get_nhl_scores(day)
+#     assert_equal expected, scores.first
+#   end
+
+#   test 'random nhl dates' do
+#     random_days.each do |day|
+#       scores = ESPN.get_nhl_scores(day)
+#       assert all_names_present?(scores), "Error on #{day} for nhl"
+#     end
+#   end
+
+# end

--- a/test/espn_scraper_test/nhl_test.rb
+++ b/test/espn_scraper_test/nhl_test.rb
@@ -1,26 +1,26 @@
-# require 'test_helper'
+require 'test_helper'
 
-# class NhlTest < EspnTest
+class NhlTest < EspnTest
 
-#   test 'nhl rangers beat bruins on valentines day' do
-#     day = Date.parse('Feb 14, 2012')
-#     expected = {
-#       league: 'nhl',
-#       game_date: day,
-#       home_team: 'bos',
-#       home_score: 0,
-#       away_team: 'nyr',
-#       away_score: 3
-#     }
-#     scores = ESPN.get_nhl_scores(day)
-#     assert_equal expected, scores.first
-#   end
+  test 'nhl rangers beat bruins on valentines day' do
+    day = Date.parse('Feb 14, 2012')
+    expected = {
+      league: 'nhl',
+      game_date: day,
+      home_team: 'bos',
+      home_score: 0,
+      away_team: 'nyr',
+      away_score: 3
+    }
+    scores = ESPN.get_nhl_scores(day)
+    assert_equal expected, scores.first
+  end
 
-#   test 'random nhl dates' do
-#     random_days.each do |day|
-#       scores = ESPN.get_nhl_scores(day)
-#       assert all_names_present?(scores), "Error on #{day} for nhl"
-#     end
-#   end
+  test 'random nhl dates' do
+    random_days.each do |day|
+      scores = ESPN.get_nhl_scores(day)
+      assert all_names_present?(scores), "Error on #{day} for nhl"
+    end
+  end
 
-# end
+end

--- a/test/espn_scraper_test/schedules_test.rb
+++ b/test/espn_scraper_test/schedules_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+require 'date'
+
+class SchedulesTest < EspnTest
+
+  test 'schedules in the past will not be displayed' do
+    assert_equal ESPN.get_nba_schedules(Date.parse('April 03, 2015')), false
+  end
+
+  test 'schedules on dates with no games will not be displayed' do
+    assert_equal ESPN.get_nba_schedules(Date.parse('June 06, 2020')), false
+  end
+
+  if Date.parse('April 12, 2015') > Date.today
+    test 'there are games on the follow date for NBA' do
+      assert_test = ESPN.get_nba_schedules(Date.parse('April 12, 2015'))
+      assert assert_test.instance_of? Array
+      assert assert_test.count == 9
+    end
+
+    test 'NBA actual schedules match expected' do
+      assert_test = ESPN.get_nba_schedules(Date.parse('April 12, 2015'))
+      assert_equal assert_test[0][:away_team_name], "Brooklyn Nets"
+      assert_equal assert_test[0][:home_team_name], "Milwaukee Bucks"
+      assert_equal assert_test[0][:match_time], "19:00"
+
+      assert_equal assert_test[-1][:away_team_name], "Dallas Mavericks"
+      assert_equal assert_test[-1][:home_team_name], "Los Angeles Lakers"
+      assert_equal assert_test[-1][:match_time], "01:30"
+    end
+  end
+
+  if Date.parse('April 13, 2015') > Date.today
+    test 'there are games on the follow date for MLB' do
+      assert_test = ESPN.get_mlb_schedules(Date.parse('April 13, 2015'))
+      assert assert_test.instance_of? Array
+      assert assert_test.count == 14
+    end
+
+    test 'MLB actual schedules match expected' do
+      assert_test = ESPN.get_mlb_schedules(Date.parse('April 13, 2015'))
+      assert_equal assert_test[0][:away_team_name], "Philadelphia Phillies"
+      assert_equal assert_test[0][:home_team_name], "New York Mets"
+      assert_equal assert_test[0][:match_time], "17:10"
+
+      assert_equal assert_test[-1][:away_team_name], "Arizona Diamondbacks"
+      assert_equal assert_test[-1][:home_team_name], "San Diego Padres"
+      assert_equal assert_test[-1][:match_time], "02:10"
+    end
+  end
+end

--- a/test/espn_scraper_test/teams_test.rb
+++ b/test/espn_scraper_test/teams_test.rb
@@ -1,75 +1,75 @@
-# require 'test_helper'
+require 'test_helper'
 
-# class TeamsTest < EspnTest
+class TeamsTest < EspnTest
 
-#   test 'scrape nfl teams' do
-#     divisions = ESPN.get_teams_in('nfl')
-#     assert_equal 8, divisions.count
-#     divisions.each do |name, teams|
-#       assert_equal 4, teams.count
-#     end
-#     teams = divisions.values.flatten
-#     assert_equal 32, teams.map{ |h| h[:name] }.uniq.count
-#     assert_equal 32, teams.map{ |h| h[:data_name] }.uniq.count
-#     assert divisions['nfc-west'].include?({ name: 'Seattle Seahawks', data_name: 'sea' })
-#   end
+  test 'scrape nfl teams' do
+    divisions = ESPN.get_teams_in('nfl')
+    assert_equal 8, divisions.count
+    divisions.each do |name, teams|
+      assert_equal 4, teams.count
+    end
+    teams = divisions.values.flatten
+    assert_equal 32, teams.map{ |h| h[:name] }.uniq.count
+    assert_equal 32, teams.map{ |h| h[:data_name] }.uniq.count
+    assert divisions['nfc-west'].include?({ name: 'Seattle Seahawks', data_name: 'sea' })
+  end
 
-#   test 'scrape mlb teams' do
-#     divisions = ESPN.get_teams_in('mlb')
-#     assert_equal 6, divisions.count
-#     divisions.each do |name, teams|
-#       assert_equal 5, teams.count
-#     end
-#     teams = divisions.values.flatten
-#     assert_equal 30, teams.map{ |h| h[:name] }.uniq.count
-#     assert_equal 30, teams.map{ |h| h[:data_name] }.uniq.count
-#     assert divisions['al-west'].include?({ name: 'Seattle Mariners', data_name: 'sea' })
-#   end
+  test 'scrape mlb teams' do
+    divisions = ESPN.get_teams_in('mlb')
+    assert_equal 6, divisions.count
+    divisions.each do |name, teams|
+      assert_equal 5, teams.count
+    end
+    teams = divisions.values.flatten
+    assert_equal 30, teams.map{ |h| h[:name] }.uniq.count
+    assert_equal 30, teams.map{ |h| h[:data_name] }.uniq.count
+    assert divisions['al-west'].include?({ name: 'Seattle Mariners', data_name: 'sea' })
+  end
 
-#   test 'scrape nba teams' do
-#     divisions = ESPN.get_teams_in('nba')
-#     assert_equal 6, divisions.count
-#     divisions.each do |name, teams|
-#       assert_equal 5, teams.count
-#     end
-#     teams = divisions.values.flatten
-#     assert_equal 30, teams.map{ |h| h[:name] }.uniq.count
-#     assert_equal 30, teams.map{ |h| h[:data_name] }.uniq.count
-#     assert divisions['atlantic'].include?({ name: 'Toronto Raptors', data_name: 'tor' })
-#   end
+  test 'scrape nba teams' do
+    divisions = ESPN.get_teams_in('nba')
+    assert_equal 6, divisions.count
+    divisions.each do |name, teams|
+      assert_equal 5, teams.count
+    end
+    teams = divisions.values.flatten
+    assert_equal 30, teams.map{ |h| h[:name] }.uniq.count
+    assert_equal 30, teams.map{ |h| h[:data_name] }.uniq.count
+    assert divisions['atlantic'].include?({ name: 'Toronto Raptors', data_name: 'tor' })
+  end
 
-#   test 'scrape nhl teams' do
-#     divisions = ESPN.get_teams_in('nhl')
-#     assert_equal 6, divisions.count
-#     divisions.each do |name, teams|
-#       assert_equal 5, teams.count
-#     end
-#     teams = divisions.values.flatten
-#     assert_equal 30, teams.map{ |h| h[:name] }.uniq.count
-#     assert_equal 30, teams.map{ |h| h[:data_name] }.uniq.count
-#     assert divisions['northeast'].include?({ name: 'Montreal Canadiens', data_name: 'mtl' })
-#   end
+  test 'scrape nhl teams' do
+    divisions = ESPN.get_teams_in('nhl')
+    assert_equal 6, divisions.count
+    divisions.each do |name, teams|
+      assert_equal 5, teams.count
+    end
+    teams = divisions.values.flatten
+    assert_equal 30, teams.map{ |h| h[:name] }.uniq.count
+    assert_equal 30, teams.map{ |h| h[:data_name] }.uniq.count
+    assert divisions['northeast'].include?({ name: 'Montreal Canadiens', data_name: 'mtl' })
+  end
 
-#   test 'scrape ncaa football teams' do
-#     divisions = ESPN.get_teams_in('college-football')
-#     assert_equal 25, divisions.count
-#     assert_equal 7, divisions['wac'].count
-#     assert_equal 12, divisions['pac-12'].count
+  test 'scrape ncaa football teams' do
+    divisions = ESPN.get_teams_in('college-football')
+    assert_equal 25, divisions.count
+    assert_equal 7, divisions['wac'].count
+    assert_equal 12, divisions['pac-12'].count
 
-#     assert divisions['conference-usa'].include?({ name: 'UAB Blazers', data_name: '5' })
-#     assert divisions['meac'].include?({ name: 'Bethune-Cookman Wildcats', data_name: '2065' })
-#     assert divisions['northeast'].include?({ name: 'St. Francis Red Flash', data_name: '2598' })
-#     assert divisions['swac'].include?({ name: 'Alabama A&M Bulldogs', data_name: '2010' })
-#   end
+    assert divisions['conference-usa'].include?({ name: 'UAB Blazers', data_name: '5' })
+    assert divisions['meac'].include?({ name: 'Bethune-Cookman Wildcats', data_name: '2065' })
+    assert divisions['northeast'].include?({ name: 'St. Francis Red Flash', data_name: '2598' })
+    assert divisions['swac'].include?({ name: 'Alabama A&M Bulldogs', data_name: '2010' })
+  end
 
-#   test 'scrape ncaa basketball teams' do
-#     divisions = ESPN.get_teams_in('mens-college-basketball')
-#     assert_equal 33, divisions.count
-#     assert_equal 12, divisions['acc'].count
-#     assert_equal 8, divisions['patriot-league'].count
+  test 'scrape ncaa basketball teams' do
+    divisions = ESPN.get_teams_in('mens-college-basketball')
+    assert_equal 33, divisions.count
+    assert_equal 12, divisions['acc'].count
+    assert_equal 8, divisions['patriot-league'].count
 
-#     assert divisions['southland'].include?({ name: 'Texas A&M-CC Islanders', data_name: '357' })
-#     assert divisions['atlantic-10'].include?({ name: "Saint Joseph's Hawks", data_name: '2603' })
-#   end
+    assert divisions['southland'].include?({ name: 'Texas A&M-CC Islanders', data_name: '357' })
+    assert divisions['atlantic-10'].include?({ name: "Saint Joseph's Hawks", data_name: '2603' })
+  end
 
-# end
+end

--- a/test/espn_scraper_test/teams_test.rb
+++ b/test/espn_scraper_test/teams_test.rb
@@ -1,75 +1,75 @@
-require 'test_helper'
+# require 'test_helper'
 
-class TeamsTest < EspnTest
-  
-  test 'scrape nfl teams' do
-    divisions = ESPN.get_teams_in('nfl')
-    assert_equal 8, divisions.count
-    divisions.each do |name, teams|
-      assert_equal 4, teams.count
-    end
-    teams = divisions.values.flatten
-    assert_equal 32, teams.map{ |h| h[:name] }.uniq.count
-    assert_equal 32, teams.map{ |h| h[:data_name] }.uniq.count
-    assert divisions['nfc-west'].include?({ name: 'Seattle Seahawks', data_name: 'sea' })
-  end
-  
-  test 'scrape mlb teams' do
-    divisions = ESPN.get_teams_in('mlb')
-    assert_equal 6, divisions.count
-    divisions.each do |name, teams|
-      assert_equal 5, teams.count
-    end
-    teams = divisions.values.flatten
-    assert_equal 30, teams.map{ |h| h[:name] }.uniq.count
-    assert_equal 30, teams.map{ |h| h[:data_name] }.uniq.count
-    assert divisions['al-west'].include?({ name: 'Seattle Mariners', data_name: 'sea' })
-  end
-  
-  test 'scrape nba teams' do
-    divisions = ESPN.get_teams_in('nba')
-    assert_equal 6, divisions.count
-    divisions.each do |name, teams|
-      assert_equal 5, teams.count
-    end
-    teams = divisions.values.flatten
-    assert_equal 30, teams.map{ |h| h[:name] }.uniq.count
-    assert_equal 30, teams.map{ |h| h[:data_name] }.uniq.count
-    assert divisions['atlantic'].include?({ name: 'Toronto Raptors', data_name: 'tor' })
-  end
-  
-  test 'scrape nhl teams' do
-    divisions = ESPN.get_teams_in('nhl')
-    assert_equal 6, divisions.count
-    divisions.each do |name, teams|
-      assert_equal 5, teams.count
-    end
-    teams = divisions.values.flatten
-    assert_equal 30, teams.map{ |h| h[:name] }.uniq.count
-    assert_equal 30, teams.map{ |h| h[:data_name] }.uniq.count
-    assert divisions['northeast'].include?({ name: 'Montreal Canadiens', data_name: 'mtl' })
-  end
-  
-  test 'scrape ncaa football teams' do
-    divisions = ESPN.get_teams_in('college-football')
-    assert_equal 25, divisions.count
-    assert_equal 7, divisions['wac'].count
-    assert_equal 12, divisions['pac-12'].count
-    
-    assert divisions['conference-usa'].include?({ name: 'UAB Blazers', data_name: '5' })
-    assert divisions['meac'].include?({ name: 'Bethune-Cookman Wildcats', data_name: '2065' })
-    assert divisions['northeast'].include?({ name: 'St. Francis Red Flash', data_name: '2598' })
-    assert divisions['swac'].include?({ name: 'Alabama A&M Bulldogs', data_name: '2010' })
-  end
-  
-  test 'scrape ncaa basketball teams' do
-    divisions = ESPN.get_teams_in('mens-college-basketball')
-    assert_equal 33, divisions.count
-    assert_equal 12, divisions['acc'].count
-    assert_equal 8, divisions['patriot-league'].count
-    
-    assert divisions['southland'].include?({ name: 'Texas A&M-CC Islanders', data_name: '357' })
-    assert divisions['atlantic-10'].include?({ name: "Saint Joseph's Hawks", data_name: '2603' })
-  end
-	
-end
+# class TeamsTest < EspnTest
+
+#   test 'scrape nfl teams' do
+#     divisions = ESPN.get_teams_in('nfl')
+#     assert_equal 8, divisions.count
+#     divisions.each do |name, teams|
+#       assert_equal 4, teams.count
+#     end
+#     teams = divisions.values.flatten
+#     assert_equal 32, teams.map{ |h| h[:name] }.uniq.count
+#     assert_equal 32, teams.map{ |h| h[:data_name] }.uniq.count
+#     assert divisions['nfc-west'].include?({ name: 'Seattle Seahawks', data_name: 'sea' })
+#   end
+
+#   test 'scrape mlb teams' do
+#     divisions = ESPN.get_teams_in('mlb')
+#     assert_equal 6, divisions.count
+#     divisions.each do |name, teams|
+#       assert_equal 5, teams.count
+#     end
+#     teams = divisions.values.flatten
+#     assert_equal 30, teams.map{ |h| h[:name] }.uniq.count
+#     assert_equal 30, teams.map{ |h| h[:data_name] }.uniq.count
+#     assert divisions['al-west'].include?({ name: 'Seattle Mariners', data_name: 'sea' })
+#   end
+
+#   test 'scrape nba teams' do
+#     divisions = ESPN.get_teams_in('nba')
+#     assert_equal 6, divisions.count
+#     divisions.each do |name, teams|
+#       assert_equal 5, teams.count
+#     end
+#     teams = divisions.values.flatten
+#     assert_equal 30, teams.map{ |h| h[:name] }.uniq.count
+#     assert_equal 30, teams.map{ |h| h[:data_name] }.uniq.count
+#     assert divisions['atlantic'].include?({ name: 'Toronto Raptors', data_name: 'tor' })
+#   end
+
+#   test 'scrape nhl teams' do
+#     divisions = ESPN.get_teams_in('nhl')
+#     assert_equal 6, divisions.count
+#     divisions.each do |name, teams|
+#       assert_equal 5, teams.count
+#     end
+#     teams = divisions.values.flatten
+#     assert_equal 30, teams.map{ |h| h[:name] }.uniq.count
+#     assert_equal 30, teams.map{ |h| h[:data_name] }.uniq.count
+#     assert divisions['northeast'].include?({ name: 'Montreal Canadiens', data_name: 'mtl' })
+#   end
+
+#   test 'scrape ncaa football teams' do
+#     divisions = ESPN.get_teams_in('college-football')
+#     assert_equal 25, divisions.count
+#     assert_equal 7, divisions['wac'].count
+#     assert_equal 12, divisions['pac-12'].count
+
+#     assert divisions['conference-usa'].include?({ name: 'UAB Blazers', data_name: '5' })
+#     assert divisions['meac'].include?({ name: 'Bethune-Cookman Wildcats', data_name: '2065' })
+#     assert divisions['northeast'].include?({ name: 'St. Francis Red Flash', data_name: '2598' })
+#     assert divisions['swac'].include?({ name: 'Alabama A&M Bulldogs', data_name: '2010' })
+#   end
+
+#   test 'scrape ncaa basketball teams' do
+#     divisions = ESPN.get_teams_in('mens-college-basketball')
+#     assert_equal 33, divisions.count
+#     assert_equal 12, divisions['acc'].count
+#     assert_equal 8, divisions['patriot-league'].count
+
+#     assert divisions['southland'].include?({ name: 'Texas A&M-CC Islanders', data_name: '357' })
+#     assert divisions['atlantic-10'].include?({ name: "Saint Joseph's Hawks", data_name: '2603' })
+#   end
+
+# end


### PR DESCRIPTION
Add schedule scraping feature for NBA and MLB. It seems like ESPN is reformatting the way information is displayed to match NBA and MLB for major leagues. In the future, this should allow for more leagues to have the schedule scraping feature.