### PR TITLE
Add schedule feature and associated tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    httparty (0.11.0)
-      multi_json (~> 1.0)
+    httparty (0.13.3)
+      json (~> 1.8)
       multi_xml (>= 0.5.2)
-    mini_portile (0.5.1)
-    multi_json (1.7.7)
-    multi_xml (0.5.4)
-    nokogiri (1.6.0)
-      mini_portile (~> 0.5.0)
-    rake (10.1.0)
+    json (1.8.2)
+    mini_portile (0.6.2)
+    multi_xml (0.5.5)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    rake (10.4.2)
 
 PLATFORMS
   ruby

--- a/lib/espn_scraper.rb
+++ b/lib/espn_scraper.rb
@@ -1,3 +1,3 @@
-%w[ boilerplate teams scores schedules ].each do |file|
-  require "espn_scraper/#{ file }"
+%w[ boilerplate teams scores schedules ].map do |file|
+  require_relative "espn_scraper/#{ file }"
 end

--- a/lib/espn_scraper.rb
+++ b/lib/espn_scraper.rb
@@ -1,3 +1,3 @@
-%w[ boilerplate teams scores ].each do |file|
+%w[ boilerplate teams scores schedules ].each do |file|
   require "espn_scraper/#{ file }"
 end

--- a/lib/espn_scraper/schedules.rb
+++ b/lib/espn_scraper/schedules.rb
@@ -10,7 +10,7 @@ module ESPN
     ## Time is returned Greenwich time
 
     # Example input:
-    # def get_nba_schedules(Date.parse("April 12,2015"))
+    # ESPN.get_nba_schedules(Date.parse("April 12,2015"))
 
     # Example output:
     # {
@@ -22,13 +22,11 @@ module ESPN
     #  }
 
     def get_nba_schedules(date)
-      league = __callee__.to_s.split("_")[1]
-      Schedules.get_schedule(league, date)
+      Schedules.get_schedule("nba", date)
     end
 
     def get_mlb_schedules(date)
-      league = __callee__.to_s.split("_")[1]
-      Schedules.get_schedule(league, date)
+      Schedules.get_schedule("mlb", date)
     end
   end
 

--- a/lib/espn_scraper/schedules.rb
+++ b/lib/espn_scraper/schedules.rb
@@ -1,0 +1,116 @@
+require 'date'
+
+module ESPN
+
+  class << self
+
+    ## Currently schedules can be retrieved by day for: NBA and MLB
+    ## ESPN Changing their website format - NFL, NHL, NCF, NCB to come
+    ## Time: day specifically, must be in the future
+    ## Time is returned Greenwich time
+
+    # Example input:
+    # def get_nba_schedules(Date.parse("April 12,2015"))
+
+    # Example output:
+    # {
+    #  :away_team_name=>"Sacramento Kings",
+    #  :away_data_name=>"sac",
+    #  :home_team_name=>"Denver Nuggets",
+    #  :home_data_name=>"den",
+    #  :match_time=>"21:00"
+    #  }
+
+    def get_nba_schedules(date)
+      league = __callee__.to_s.split("_")[1]
+      Schedules.get_schedule(league, date)
+    end
+
+    def get_mlb_schedules(date)
+      league = __callee__.to_s.split("_")[1]
+      Schedules.get_schedule(league, date)
+    end
+  end
+
+  module Schedules
+
+    class << self
+
+      def get_schedule(league, date)
+        markup = markup_from_date(league, date)
+        if games_available?(markup, date)
+          teams_name_info = team_data_name(markup)
+          dates_info = greenwich_time(markup)
+          schedule = parse_schedule(teams_name_info, dates_info)
+        else
+          false
+        end
+      end
+
+      private
+
+      def games_available?(markup, date)
+        if date <= Date.today
+          puts "ERROR: Digging Into Past Games Not Allowed"
+          false
+        elsif markup == nil
+          puts "ERROR: No Games Scheduled"
+          false
+        else
+          true
+        end
+      end
+
+      def markup_from_date(league, date)
+        formatted_date = date.to_s.gsub(/[^\d]+/, '')
+        all_markup_on_page = ESPN.get league, "schedule?date=#{ formatted_date }"
+        markup_for_day = all_markup_on_page.at_css("tbody")
+      end
+
+      def team_data_name(markup)
+        team_and_data_names=[]
+        full_team_and_data_names=markup.children.css("abbr")
+        full_team_and_data_names.each_with_index do |team_and_data_name, i|
+          team_and_data_names << {team_name: team_and_data_name.attributes.values[0].value, data_name: team_and_data_name.text().downcase}
+        end
+        team_and_data_names.each_slice(2).to_a
+      end
+
+      def greenwich_time(markup)
+        green_times_array=[]
+        green_times = markup.children.css("td[data-date]")
+        green_times.each do |green_time|
+          green_time.attributes.each do |noko_value|
+            if noko_value[0] == "data-date"
+              green_times_array << grab_time(noko_value[1].value)
+            end
+          end
+        end
+        green_times_array
+      end
+
+      def grab_time(unformated_time)
+        time_index_locator = unformated_time.split("").find_index("T")+1
+        unformated_time.slice(time_index_locator..-2)
+      end
+
+      def parse_schedule(teams, times)
+        future_games_no = times.count
+        parsed_schedules = []
+        parsed_schedule = {away_team_name: nil, away_data_name: nil, home_team_name: nil, home_data_name:nil, match_time: nil}
+
+        future_games_no.times do |count|
+          parse_schedule_dup = parsed_schedule.dup
+          parse_schedule_dup[:away_team_name] = teams[count][0][:team_name]
+          parse_schedule_dup[:away_data_name] = teams[count][0][:data_name]
+          parse_schedule_dup[:home_team_name] = teams[count][1][:team_name]
+          parse_schedule_dup[:home_data_name] = teams[count][1][:data_name]
+          parse_schedule_dup[:match_time] = times[count]
+          parsed_schedules << parse_schedule_dup
+        end
+        parsed_schedules
+      end
+
+    end
+  end
+end

--- a/test/espn_scraper_test/schedules_test.rb
+++ b/test/espn_scraper_test/schedules_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+require 'date'
+
+class SchedulesTest < EspnTest
+
+  test 'schedules in the past will not be displayed' do
+    assert_equal ESPN.get_nba_schedules(Date.parse('April 03, 2015')), false
+  end
+
+  test 'schedules on dates with no games will not be displayed' do
+    assert_equal ESPN.get_nba_schedules(Date.parse('June 06, 2020')), false
+  end
+
+  if Date.parse('April 12, 2015') > Date.today
+    test 'there are games on the follow date for NBA' do
+      assert_test = ESPN.get_nba_schedules(Date.parse('April 12, 2015'))
+      assert assert_test.instance_of? Array
+      assert assert_test.count == 9
+    end
+
+    test 'NBA actual schedules match expected' do
+      assert_test = ESPN.get_nba_schedules(Date.parse('April 12, 2015'))
+      assert_equal assert_test[0][:away_team_name], "Brooklyn Nets"
+      assert_equal assert_test[0][:home_team_name], "Milwaukee Bucks"
+      assert_equal assert_test[0][:match_time], "19:00"
+
+      assert_equal assert_test[-1][:away_team_name], "Dallas Mavericks"
+      assert_equal assert_test[-1][:home_team_name], "Los Angeles Lakers"
+      assert_equal assert_test[-1][:match_time], "01:30"
+    end
+  end
+
+  if Date.parse('April 13, 2015') > Date.today
+    test 'there are games on the follow date for MLB' do
+      assert_test = ESPN.get_mlb_schedules(Date.parse('April 13, 2015'))
+      assert assert_test.instance_of? Array
+      assert assert_test.count == 14
+    end
+
+    test 'MLB actual schedules match expected' do
+      assert_test = ESPN.get_mlb_schedules(Date.parse('April 13, 2015'))
+      assert_equal assert_test[0][:away_team_name], "Philadelphia Phillies"
+      assert_equal assert_test[0][:home_team_name], "New York Mets"
+      assert_equal assert_test[0][:match_time], "17:10"
+
+      assert_equal assert_test[-1][:away_team_name], "Arizona Diamondbacks"
+      assert_equal assert_test[-1][:home_team_name], "San Diego Padres"
+      assert_equal assert_test[-1][:match_time], "02:10"
+    end
+  end
+end


### PR DESCRIPTION
Adding new schedule feature to gem. Allows users to grab NBA and MLB future game times. It seems ESPN is converting other major sports to same format, so adding NFL, NHL, NCB, and NCF, will be pretty simple in the future.
