### PR TITLE
Fix broken MLB scores again

### DIFF
--- a/lib/espn_scraper/scores.rb
+++ b/lib/espn_scraper/scores.rb
@@ -167,8 +167,15 @@ module ESPN
     
       def home_away_parse(doc, date)
         scores = []
-        espn_data = JSON.parse(doc.css('#scoreboard-page').first.attr('data-data'))
-        games = espn_data['events']
+        games = []
+        espn_regex = /window\.espn\.scoreboardData \t= (\{.*?\});/
+        doc.xpath("//script").each do |script_section|
+          if script_section.content =~ espn_regex
+            espn_data = JSON.parse(espn_regex.match(script_section.content)[1])
+            games = espn_data['events']
+            break
+          end
+        end
         games.each do |game|
           # Game must be regular season
           next unless game['season']['type'] == 2


### PR DESCRIPTION
Looks like ESPN changed up their layout again for MLB scoreboard pages. Instead of putting the scoreboard JSON data in an HTML attribute, now it's hiding inside JS code inline on the page. Although slightly gross, this new code extracts the JSON using a regular expression. All tests are passing for me.