### PR TITLE
Switch NFL scores over to new parsing strategy

### DIFF
--- a/lib/espn_scraper/scores.rb
+++ b/lib/espn_scraper/scores.rb
@@ -71,21 +71,21 @@ module ESPN
     
     def get_nfl_scores(year, week)
       markup = Scores.markup_from_year_and_week('nfl', year, week)
-      scores = Scores.visitor_home_parse(markup, 'nfl')
+      scores = Scores.home_away_parse(markup)
       add_league_and_fixes(scores, 'nfl')
       scores
     end
     
     def get_mlb_scores(date)
       markup = Scores.markup_from_date('mlb', date)
-      scores = Scores.home_away_parse(markup, date)
+      scores = Scores.home_away_parse(markup)
       scores.each { |report| report[:league] = 'mlb' }
       scores
     end
     
     def get_nba_scores(date)
       markup = Scores.markup_from_date('nba', date)
-      scores = Scores.home_away_parse(markup, date)
+      scores = Scores.home_away_parse(markup)
       scores.each { |report| report[:league] = 'nba' }
       scores
     end
@@ -163,7 +163,7 @@ module ESPN
         game_scores
       end
     
-      def home_away_parse(doc, date)
+      def home_away_parse(doc)
         scores = []
         games = []
         espn_regex = /window\.espn\.scoreboardData \t= (\{.*?\});/
@@ -177,7 +177,7 @@ module ESPN
         games.each do |game|
           # Game must be regular season
           next unless game['season']['type'] == 2
-          score = { game_date: date }
+          score = {}
           competition = game['competitions'].first
           # Score must be final
           if competition['status']['type']['detail'] =~ /^Final/
@@ -190,6 +190,7 @@ module ESPN
                 score[:away_score] = competitor['score'].to_i
               end
             end
+            score[:game_date] = DateTime.parse(game['date'])
             scores << score
           end
         end

--- a/test/espn_scraper_test/mlb_test.rb
+++ b/test/espn_scraper_test/mlb_test.rb
@@ -3,30 +3,30 @@ require 'test_helper'
 class MlbTest < EspnTest
   
   test 'mlb august 13th 2012 yankees beat rangers' do
-    day = Date.parse('Aug 13, 2012')
+    starts_at = DateTime.parse('2012-08-13T23:00:00+00:00')
     expected = {
       league: 'mlb',
-      game_date: day,
+      game_date: starts_at,
       home_team: 'nyy',
       home_score: 8,
       away_team: 'tex',
       away_score: 2
     }
-    scores = ESPN.get_mlb_scores(day)
+    scores = ESPN.get_mlb_scores(starts_at.to_date)
     assert scores.include?(expected), 'A known MLB final score cannot be found'
   end
 
   test 'mlb april 18th 2015 blue jays beat braves in extra innings' do
-    day = Date.parse('Apr 18, 2015')
+    starts_at = DateTime.parse('2015-04-18T17:07:00+00:00')
     expected = {
         league: 'mlb',
-        game_date: day,
+        game_date: starts_at,
         home_team: 'tor',
         home_score: 6,
         away_team: 'atl',
         away_score: 5
     }
-    scores = ESPN.get_mlb_scores(day)
+    scores = ESPN.get_mlb_scores(starts_at.to_date)
     assert scores.include?(expected), 'A known MLB final score cannot be found'
   end
   

--- a/test/espn_scraper_test/nba_test.rb
+++ b/test/espn_scraper_test/nba_test.rb
@@ -6,7 +6,7 @@ class NbaTest < EspnTest
     day = Date.parse('Dec 25, 2012')
     expected = {
       league: 'nba',
-      game_date: day,
+      game_date: DateTime.parse('2012-12-25T17:00:00+00:00'),
       home_team: 'bkn',
       home_score: 76,
       away_team: 'bos',

--- a/test/espn_scraper_test/ncf_test.rb
+++ b/test/espn_scraper_test/ncf_test.rb
@@ -3,9 +3,10 @@ require 'test_helper'
 class NcfTest < EspnTest
   
   test 'college football 2012 week 9 regular season' do
+    starts_at = DateTime.parse('2012-10-23T00:00:00+00:00')
     expected = {
       league: 'college-football',
-      game_date: Date.parse('Oct 23, 2012'),
+      game_date: starts_at,
       home_team: '309',
       home_score: 27,
       away_team: '2032',

--- a/test/espn_scraper_test/nfl_test.rb
+++ b/test/espn_scraper_test/nfl_test.rb
@@ -9,9 +9,10 @@ class NflTest < EspnTest
   end
   
   test 'nfl 2012 week 8 regular season' do
+    starts_at = DateTime.parse('2012-10-26T00:20Z')
     expected = {
       league: 'nfl',
-      game_date: Date.parse('Oct 25, 2012'),
+      game_date: starts_at,
       home_team: 'min',
       home_score: 17,
       away_team: 'tb',
@@ -22,9 +23,10 @@ class NflTest < EspnTest
   end
   
   test 'nfl 2012 week 7 regular season' do
+    starts_at = DateTime.parse('2012-10-23T00:30:00+00:00')
     expected = {
       league: 'nfl',
-      game_date: Date.parse('Oct 22, 2012'),
+      game_date: starts_at,
       home_team: 'chi',
       home_score: 13,
       away_team: 'det',

--- a/test/espn_scraper_test/teams_test.rb
+++ b/test/espn_scraper_test/teams_test.rb
@@ -53,8 +53,8 @@ class TeamsTest < EspnTest
     divisions = ESPN.get_teams_in('college-football')
     assert_equal 25, divisions.count
     assert_equal 12, divisions['pac-12'].count
-    
-    assert divisions['conference-usa'].include?({ name: 'UAB Blazers', data_name: '5' })
+
+    assert divisions['conference-usa'].include?({ name: 'Rice Owls', data_name: '242' })
     assert divisions['meac'].include?({ name: 'Bethune-Cookman Wildcats', data_name: '2065' })
     assert divisions['northeast'].include?({ name: 'St Francis Red Flash', data_name: '2598' })
     assert divisions['swac'].include?({ name: 'Alabama A&M Bulldogs', data_name: '2010' })
@@ -62,7 +62,7 @@ class TeamsTest < EspnTest
   
   test 'scrape ncaa basketball teams' do
     divisions = ESPN.get_teams_in('mens-college-basketball')
-    assert_equal 33, divisions.count
+    assert_equal 32, divisions.count
     assert_equal 15, divisions['acc'].count
     assert_equal 10, divisions['patriot-league'].count
     


### PR DESCRIPTION
This changes NFL scraping over to the new JSON based parsing strategy that we introduced in #4. It simplifies a few of our internal methods. It also scrapes a DateTime for the game dates instead of just a Date. Tests have been updated as well.