### PR TITLE
Fix NCB score scraping by requiring filter by conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ ESPN.get_divisions
 # }
 ```
 
+#### Scrape Conferences (NCAA D1 Men's Basketball only)
+
+You can get all the conferences in NCAA D1 Men's Basketball.
+
+```ruby
+ESPN.get_conferences_in_ncb
+# => [{:name=>"America East", :data_name=>"1"},
+#      {:name=>"American", :data_name=>"62"},
+#      ...
+      ]
+```
+
 #### Scrape teams
 
 You can get the teams in each league by acronym. It returns a hash of each division with an array of hashes for each team in the division.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ ESPN.get_conferences_in_ncb
 # => [{:name=>"America East", :data_name=>"1"},
 #      {:name=>"American", :data_name=>"62"},
 #      ...
-      ]
+#      ]
 ```
 
 #### Scrape teams

--- a/lib/espn_scraper/teams.rb
+++ b/lib/espn_scraper/teams.rb
@@ -23,6 +23,14 @@ module ESPN
         { name: name, data_name: div_data_name(name) }
       end
     end
+
+    def get_conferences_in_ncb
+      get_ncb_conferences.map do |element|
+        name = element.content
+        data_name = $1 if element.children[0].attributes['href'].value =~ /confId=(\d+)/
+        { name: name, data_name: data_name }
+      end
+    end
     
     def get_teams_in(league)
       divisions = {}
@@ -52,6 +60,10 @@ module ESPN
     
     def get_divs(league)
       self.get(league, 'teams').css('.mod-teams-list-medium')
+    end
+
+    def get_ncb_conferences
+      self.get('ncb', 'conferences').css('.mod-content h5')
     end
     
     def parse_div_name(div)

--- a/lib/espn_scraper/version.rb
+++ b/lib/espn_scraper/version.rb
@@ -1,3 +1,3 @@
 module ESPN
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end

--- a/test/espn_scraper_test/ncb_test.rb
+++ b/test/espn_scraper_test/ncb_test.rb
@@ -3,23 +3,26 @@ require 'test_helper'
 class NcbTest < EspnTest
   
   test 'mens college basketball march 15th murray state beats colorado state' do
-    day = Date.parse('Mar 15, 2012')
+    day = Date.parse('2012-03-15')
+    league = 'mens-college-basketball'
     expected = {
-      league: 'mens-college-basketball',
+      league: league,
       game_date: day,
-      home_team: '93',
+      home_team: 'murr',
       home_score: 58,
-      away_team: '36',
+      away_team: 'csu',
       away_score: 41
     }
-    scores = ESPN.get_college_basketball_scores(day)
+    mountain_west_conf = ESPN.get_conferences_in_ncb.select {|c| c[:name] == 'Mountain West' }.first
+    scores = ESPN.get_college_basketball_scores(day, mountain_west_conf[:data_name])
     assert_equal expected, scores.first
   end
   
 
   test 'random ncb dates' do
     random_days.each do |day|
-      scores = ESPN.get_college_basketball_scores(day)
+      random_conf = ESPN.get_conferences_in_ncb.sample
+      scores = ESPN.get_college_basketball_scores(day, random_conf[:data_name])
       assert all_names_present?(scores), "Error on #{day} for college basketball"
     end
   end

--- a/test/espn_scraper_test/teams_test.rb
+++ b/test/espn_scraper_test/teams_test.rb
@@ -69,5 +69,11 @@ class TeamsTest < EspnTest
     assert divisions['southland'].include?({ name: 'Texas A&M-CC Islanders', data_name: '357' })
     assert divisions['atlantic-10'].include?({ name: "Saint Joe's Saint Joseph's Hawks", data_name: '2603' })
   end
+
+  test 'scrape ncaa basketball conferences' do
+    conferences = ESPN.get_conferences_in_ncb
+    assert_equal 32, conferences.count
+    assert conferences.include?({ name: 'Mountain West', data_name: '44' })
+  end
 	
 end


### PR DESCRIPTION
The test for NCB/men's college basketball score scraping was failing. Here I fixed it by requiring a conference ID when scraping those scores. It seems like scores for all conferences used to come back on one page but now ESPN breaks them up so each conference's scores are on a separate page. This also exposes a way of getting the list of conferences.